### PR TITLE
ci: prefer requirements-dev.txt lockfile; ignore Zone.Identifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          if [ -f requirements-dev.txt ]; then
+            python -m pip install -r requirements-dev.txt -e .
+          else
+            python -m pip install -e ".[dev]"
+          fi
 
       - name: Check
         run: make check

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ htmlcov/
 
 # local backups
 .gitignore.bak.*
+
+*:Zone.Identifier
+


### PR DESCRIPTION
Use lockfiles in CI when present; ignore Windows Zone.Identifier artifacts.