### PR TITLE
ci: include requirements*.txt in pip cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install
         run: |


### PR DESCRIPTION
Improve pip cache invalidation by including requirements.txt and requirements-dev.txt via cache-dependency-path.