### PR TITLE
build: uv lock targets + workflow docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,19 @@
 Требования:
 - Python 3.12+
 - (опционально) Ollama для интеграционных тестов
+- (опционально) `uv` для генерации `requirements*.txt`
 
 Установка:
 ```bash
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install -U pip
+
+# Быстро: из pyproject.toml
 pip install -e ".[dev]"
+
+# Как в CI: из requirements-dev.txt
+# make sync
 ```
 
 Проверки:
@@ -21,6 +27,22 @@ pip install -e ".[dev]"
 make check
 make makefile-smoke
 ```
+
+## Lockfiles (uv)
+
+В репозитории поддерживаются `requirements.txt` и `requirements-dev.txt`, генерируемые из `pyproject.toml`.
+
+Обновить:
+```bash
+make lock
+```
+
+Проверить, что lockfiles не “уплыли”:
+```bash
+make lock-check
+```
+
+Если PR меняет зависимости (например, Dependabot), в идеале в PR должны быть согласованные изменения в `pyproject.toml` и `requirements*.txt`.
 
 ## Ветвление и PR
 

--- a/docs/dev_workflow.md
+++ b/docs/dev_workflow.md
@@ -8,8 +8,62 @@
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install -U pip
+
+# Быстрый вариант (ставим из pyproject.toml)
 pip install -e ".[dev]"
+
+# Вариант “как в CI” (пинованные зависимости из requirements-dev.txt)
+# make sync
 ```
+
+## Lockfiles (uv)
+
+В репозитории есть два “lockfile-подобных” файла, генерируемых из `pyproject.toml`:
+
+- `requirements.txt` — runtime зависимости
+- `requirements-dev.txt` — runtime + dev (`--extra dev`)
+
+Генерация делается через `uv pip compile`.
+
+### Команды
+
+Сгенерировать/обновить оба файла:
+```bash
+make lock
+```
+
+Проверить, что локальные `requirements*.txt` соответствуют `pyproject.toml` (пересобирает и падает, если есть diff):
+```bash
+make lock-check
+```
+
+Синхронизировать окружение “как в CI” (нужны существующие `requirements-dev.txt`):
+```bash
+make sync
+```
+
+### Как обновлять после Dependabot PR
+
+Dependabot может обновлять:
+
+- `requirements*.txt` напрямую (чаще всего для `pip` ecosystem)
+- `pyproject.toml` (если он соответствует PEP 621)
+
+Рекомендованный порядок действий для PR с обновлениями зависимостей:
+
+1) Смёрджить PR нельзя, пока CI зелёный.
+2) Локально прогнать:
+   ```bash
+   make check
+   make lock-check
+   ```
+3) Если `make lock-check` упал (появился diff), то:
+   ```bash
+   make lock
+   git add requirements.txt requirements-dev.txt
+   git commit -m "deps: regen requirements via uv"
+   ```
+   и допушить коммит в ветку PR.
 
 ## Quality gates
 


### PR DESCRIPTION
## Что сделано

- Добавлены Makefile-таргеты для uv-based lockfiles:
  - `make lock` — генерирует `requirements.txt` и `requirements-dev.txt` из `pyproject.toml` (extra `dev`)
  - `make lock-check` — пересобирает lockfiles и падает при diff (`git diff --exit-code`)
  - `make sync` — установка зависимостей из `requirements-dev.txt` + editable install проекта
- Обновлена документация:
  - `docs/dev_workflow.md` — секция про lockfiles и порядок действий после Dependabot PR
  - `CONTRIBUTING.md` — краткая секция про lockfiles и команды

## Почему

Нужно “production-like” воспроизводимое окружение:
- единый источник правды — `pyproject.toml`,
- стабильные `requirements*.txt` для CI/пользователей,
- явный workflow обновления после Dependabot PR.

## Как проверить

Команды:
- [x] `make check`
- [x] `make makefile-smoke`
- [x] `make lock-check`
- [ ] `make integration` (не затрагивалось)

Ручная проверка (если есть):
- [ ] `make local-llm ARGS='chat --prompt "ping" --stream'` (не затрагивалось)

## Связанные задачи

- Related: (нет)

## Чеклист

- [x] Добавлены/обновлены тесты (не требуется: только build/docs)
- [x] Обновлена документация (workflow/CONTRIBUTING)
- [x] Нет секретов/ключей в коде/логах
- [x] Изменения соответствуют стилю проекта (ruff/mypy/pytest зелёные)
