### PR TITLE
docs: document lock-check and uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - `ruff` (format + lint)
   - `mypy` (строго)
   - `mypy-smoke` (`reveal_type` для overload’ов)
+  - `lock-check` (uv: `requirements*.txt` соответствуют `pyproject.toml`)
   - `pytest` unit
   - `pytest` integration (для Ollama)
 
@@ -191,6 +192,31 @@ python scripts/local_llm.py chat --prompt "Расскажи про миграц�
 
 ## Разработка и проверки
 
+### Lockfiles (uv)
+
+В репозитории поддерживаются `requirements.txt` и `requirements-dev.txt`, которые **генерируются из `pyproject.toml` через `uv`**.
+В CI есть отдельный job `lock-check`, который запускает `make lock-check` и падает на diff.
+
+Установить `uv` (один раз локально):
+```bash
+python -m pip install -U uv
+```
+
+Обновить lockfiles:
+```bash
+make lock
+```
+
+Проверить, что lockfiles не “уплыли”:
+```bash
+make lock-check
+```
+
+Установить зависимости “как в CI” (из `requirements-dev.txt`):
+```bash
+make sync
+```
+
 Главная команда:
 
 ```bash
@@ -199,6 +225,8 @@ make check
 
 Полезные таргеты:
 
+- `make lock` / `make lock-check` (требует `uv`)
+- `make sync` (установка зависимостей как в CI: из `requirements-dev.txt`)
 - `make format` / `make format-check`
 - `make lint`
 - `make typecheck`


### PR DESCRIPTION
## Что сделано

- Обновлён README: добавлено описание `lock-check` (uv) как quality gate в CI.
- Добавлен раздел “Lockfiles (uv)” с командами:
  - `make lock`
  - `make lock-check`
  - `make sync`

## Почему

`lock-check` теперь является required status check, поэтому важно документировать:
- откуда берутся `requirements.txt` / `requirements-dev.txt`,
- как локально обновлять и проверять lockfiles,
- как поставить зависимости “как в CI”.

## Как проверить

- `make lock-check`
- `make check`

## Связанные задачи

- Related: CI lock-check job + branch protection required check

## Чеклист

- [ ] Добавлены/обновлены тесты (или аргументировано не нужны)
- [x] Обновлена документация (если поведение/CLI изменились)
- [x] Нет секретов/ключей в коде/логах/скриншотах
- [x] Изменения соответствуют стилю проекта (ruff/mypy/pytest зелёные)
